### PR TITLE
Updating version numbers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlinxSerializationJson = "1.7.1"
 kotlinxSerializationPlugin = "2.0.0"
 dokka = "1.9.20"
 androidxTest = "1.6.1"
-rtviClient = "0.1.2"
+rtviClient = "0.1.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/rtvi-client-android-daily/build.gradle.kts
+++ b/rtvi-client-android-daily/build.gradle.kts
@@ -64,7 +64,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "ai.rtvi"
             artifactId = "client-daily"
-            version = "0.1.3"
+            version = "0.1.4"
 
             pom {
                 name.set("RTVI Client Daily Transport")


### PR DESCRIPTION
CI won't pass until `rtvi-client-android` 0.1.4 is published.